### PR TITLE
Switch comms with INA219 to third I2C controller

### DIFF
--- a/software/GPSDO.ino
+++ b/software/GPSDO.ino
@@ -187,6 +187,7 @@ Adafruit_AHTX0 aht;                                // create object aht
 #include <LapINA219.h>                             // LapINA219 library library
 LapINA219 ina219(0x40);                            // create object ina219 with I2C address 0x40
 float ina219volt=0.0, ina219curr=0.0;
+TwoWire Wire3(PB4,PA8);                            // Second TwoWire instance for INA219 on SDA3/SCL3 (should be put somewhere more fitting but must stay global)
 #endif // INA219
 
 #ifdef GPSDO_OLED
@@ -732,7 +733,7 @@ void setup()
   #endif // OLED 
   
   #ifdef GPSDO_INA219
-  ina219.begin();                           // calibrates ina219 sensor
+  ina219.begin(&Wire3);                           // calibrates ina219 sensor Edit: start the sensor on the third I2C controller
   Wire.setClock(400000L); 
   #endif // INA219 
 


### PR DESCRIPTION
- Added a second I2C instance to communicate with the INA219 on the third I2C interface (SDA3/SCL3)
- Changed the INA219 initialisation to use Wire3 in accordance with the LapINA219 library's documentation

I've built the GPSDO circuit according to the schematic you published on EEVblog and noticed in your code's description that you had some trouble with the INA219 sensor. When i've built it, the serial didn't put out any values for the sensor and i couldn't find where you differentiate between the two I2C controllers used in your project. Since the INA219 is the only node on I2C-3 i created a second TwoWire instance and changed the INA219 initialisation to use the interface specified in the new instance. Tests have been running successfully, no lockups occured after uptimes of at least 1h and fluctuating heating current readouts through serial (sensor working). 
Maybe you find this useful, this is my first github contribution ever so just disregard it if it doesn't make any sense.